### PR TITLE
Updates random number generation

### DIFF
--- a/django_pph/management/commands/initialize_pph_context.py
+++ b/django_pph/management/commands/initialize_pph_context.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.contrib.auth.hashers import get_hasher
 from django.utils.crypto import get_random_string
+from os import urandom
 
 from django_pph.shamirsecret import ShamirSecret
 from django_pph.settings import SETTINGS
@@ -29,14 +30,15 @@ class Command(BaseCommand):
 
     def create_secret(self):
         """
-        Returns a random string consisting of 28 bytes of random data
-        and 4 bytes of hash to verify the secret upon recombination
+        Returns a random string consisting of secret_length bytes of random
+        data and verification_length bytes of hash to verify the secret upon
+        recombination
         """
         secret_length = SETTINGS['SECRET_LENGTH']
         verification_len = SETTINGS['SECRET_VERIFICATION_BYTES']
         verification_iterations = SETTINGS['SECRET_ITERATIONS']
-        
-        secret = get_random_string(secret_length - verification_len)
+
+        secret = urandom(secret_length - verification_len)
 
         secret_digest = self.hasher.digest(secret, '', 1)
         for i in range(1, verification_iterations):
@@ -44,5 +46,5 @@ class Command(BaseCommand):
         secret_digest = bin64enc(secret_digest)
 
         
-        secret += secret_digest[:SETTINGS['SECRET_VERIFICATION_BYTES']]
+        secret += binary_type(secret_digest[:SETTINGS['SECRET_VERIFICATION_BYTES']])
         return binary_type(secret)


### PR DESCRIPTION
Random number generation is now defaulted to os.urandom, since it can
provide the whole byte-range of values. Urandom is considered to provide
cryptographically-secure random strings.

Props to @free-Runner for catching this on #4 