### PR TITLE
ENH: Add django 1.9 compliant code

### DIFF
--- a/django_pph/management/commands/demote_user.py
+++ b/django_pph/management/commands/demote_user.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
     help = 'Remove a user from the thresholdless-account pool'
 
     def add_arguments(self, parser):
-        parser.add_argument('user_id', nargs='+', type=int,
+        parser.add_argument('user_id', nargs='+',
                             help=('the target username to add to '
                                   'thresholdless accounts'))
 
@@ -64,4 +64,5 @@ class Command(BaseCommand):
 
         # FIXME: we should support the options arguments or detect different
         # django versions for it.
-        demote_user(args[0])
+        for user in options['user_id']:
+            demote_user(user)

--- a/django_pph/management/commands/promote_user.py
+++ b/django_pph/management/commands/promote_user.py
@@ -24,16 +24,16 @@ def promote_user(username):
         user.password = new_password
         user.save()
 
-
 class Command(BaseCommand):
 
     help = 'Adds a thresholdless user to the threshold accounts'
 
     def add_arguments(self, parser):
-        parser.add_argument('user_id', nargs='+', type=int,
+        parser.add_argument('user_id', nargs='+',
                             help=("the target username to add to "
                                   "thresholdless accounts"))
 
     def handle(self, *args, **options):
 
-        promote_user(args[0])
+        for username in options['user_id']:
+            promote_user(username)

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -53,33 +53,36 @@ ROOT_URLCONF = 'example_project.urls'
 
 WSGI_APPLICATION = 'example_project.wsgi.application'
 
+# Internationalization
+# https://docs.djangoproject.com/en/1.6/topics/i18n/
 
-# Database
-# https://docs.djangoproject.com/en/1.6/ref/settings/#databases
+DEBUG=True
 
-DATABASES = {
+DATABASES={
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': 'test.db'
     }
 }
 
-PASSWORD_HASHERS = (
-    'django_pph.hashers.PolyPasswordHasherer',
+PASSWORD_HASHERS=(
+'django_pph.hashers.PolyPasswordHasher',
 )
 
-CACHES = {
+CACHES={
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
     'pph': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '127.0.0.1:11211',
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': 'pph_cache',
+        'TIMEOUT': None,
+    },
+    'share_cache': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'share_table',
     }
 }
-
-# Internationalization
-# https://docs.djangoproject.com/en/1.6/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -53,23 +53,18 @@ ROOT_URLCONF = 'example_project.urls'
 
 WSGI_APPLICATION = 'example_project.wsgi.application'
 
-# Internationalization
-# https://docs.djangoproject.com/en/1.6/topics/i18n/
-
-DEBUG=True
-
-DATABASES={
+DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': 'test.db'
     }
 }
 
-PASSWORD_HASHERS=(
-'django_pph.hashers.PolyPasswordHasher',
+PASSWORD_HASHERS = (
+    'django_pph.hashers.PolyPasswordHasher',
 )
 
-CACHES={
+CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
@@ -83,6 +78,9 @@ CACHES={
         'LOCATION': 'share_table',
     }
 }
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.10/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 


### PR DESCRIPTION
The management commands within django_pph, as well as the example application,
wasn't django 1.9 (or 1.10) ready, which made testing rather difficult. This PR
includes the code necessary to run these examples out of the bat with current
django versions.